### PR TITLE
Add support for schema definitions + references

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -174,15 +174,13 @@ function addSchemaParameters(parameters, location, schema) {
 
 function outputToSwagger (respJson) {
   let obj = {};
-  if (respJson) {
+  if (respJson && respJson.body) {
     if (respJson.ref) {
       obj.schema = {"$ref": respJson.ref}
     } else {
-      if (respJson.body) {
-        obj.schema = j2s(respJson.body).swagger;
-        if (respJson.schema || obj.schema.description) {
-          obj.description = respJson.schema || obj.schema.description;
-        }
+      obj.schema = j2s(respJson.body).swagger;
+      if (respJson.schema || obj.schema.description) {
+        obj.description = respJson.schema || obj.schema.description;
       }
     }
   }

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -174,10 +174,16 @@ function addSchemaParameters(parameters, location, schema) {
 
 function outputToSwagger (respJson) {
   let obj = {};
-  if (respJson && respJson.body) {
-    obj.schema = j2s(respJson.body).swagger;
-    if (respJson.schema || obj.schema.description) {
-      obj.description = respJson.schema || obj.schema.description;
+  if (respJson) {
+    if (respJson.ref) {
+      obj.schema = {"$ref": respJson.ref}
+    } else {
+      if (respJson.body) {
+        obj.schema = j2s(respJson.body).swagger;
+        if (respJson.schema || obj.schema.description) {
+          obj.description = respJson.schema || obj.schema.description;
+        }
+      }
     }
   }
   return obj;

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -243,12 +243,20 @@ exports.validateToSwaggerParameters = function(validate) {
   }
 
   if (validate.body) {
-    let swaggerSchema = j2s(validate.body).swagger;
-    parameters.push({
-      name: 'body',
-      in: 'body',
-      schema: swaggerSchema
-    });
+    if (validate.ref) {
+      parameters.push({
+        name: 'body',
+        in: 'body',
+        schema: {"$ref": validate.ref}
+      });
+    } else {
+      let swaggerSchema = j2s(validate.body).swagger;
+      parameters.push({
+        name: 'body',
+        in: 'body',
+        schema: swaggerSchema
+      });
+    }
   }
   return parameters;
 };


### PR DESCRIPTION
As it stands, swagger/openapi code generators won't generate named models from the resulting API spec. This PR let's you define a reference in your Joi validator like so:

```javascript
validate: {
    output: {
        200: {
            body: Profile.joi,
            ref: "#/definitions/Profile"
        }
        ...
    }
}
```

and then throw your definition in
```javascript
swaggerGenerator.generateSpec({
    ...
    definitions: {
        'Profile': j2s(Profile.joi).swagger
    }
}
```

I figured it'd be useful to merge this to master for anybody else using this package for code generation. 