### PR TITLE
Change swagger API document CDN

### DIFF
--- a/example/routes.js
+++ b/example/routes.js
@@ -163,7 +163,7 @@ router.get('/apiDocs', async ctx => {
   </head>
   <body>
     <redoc spec-url='/_api.json' lazy-rendering></redoc>
-    <script src="https://rebilly.github.io/ReDoc/releases/latest/redoc.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"></script>
   </body>
   </html>
   `


### PR DESCRIPTION
It does not describe **required** at path parameters and **nullable** at response object body like this below picture. 

Here is Joi schema.

see, https://github.com/Redocly/redoc

```typescript
meta: {
    ...
},
validate: {
    params: {
        _id: Joi.string().alphanum().max(24).example('abcdefg').description('User id').required() // <- note here
    },
    output: {
        '200-299': {
            body: Joi.object({
                userId: Joi.string().allow(null).required().description('User id') // <- note here
            }).options({
                    allowUnknown: true
            }).description('User object')
        },
        500: {
            body: Joi.object({
                message: Joi.string().description('error message') 
            }).description('error body')
         }
},
handler: async (ctx) => {
    ....
}
```




- before
![image](https://user-images.githubusercontent.com/26626706/86464224-04076d00-bd6a-11ea-8256-aaae30bf853b.png)


- after 
![image](https://user-images.githubusercontent.com/26626706/86464272-1d101e00-bd6a-11ea-9228-0f0da318340c.png)
