### PR TITLE
fix: Fixed issues due to deprecated @hapi/joi package

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -3,7 +3,7 @@
 const assert = require('assert');
 const cloneDeep = require('lodash/cloneDeep');
 const get = require('lodash/get');
-const j2s = require('o2team-joi-to-swagger');
+const j2s = require('joi-to-swagger');
 const generator = require('./generator');
 const each = require('lodash/each');
 

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -1,7 +1,7 @@
 'use strict';
 const pathToRegex = require('path-to-regexp');
 
-const j2s = require('o2team-joi-to-swagger');
+const j2s = require('joi-to-swagger');
 const each = require('lodash/each');
 const pick = require('lodash/pick');
 const get = require('lodash/get');

--- a/package.json
+++ b/package.json
@@ -19,13 +19,13 @@
   "license": "MIT",
   "dependencies": {
     "lodash": "^4.17.15",
-    "o2team-joi-to-swagger": "^3.2.2",
+    "joi-to-swagger": "^5.2.0",
     "path-to-regexp": "^3.0.0"
   },
   "devDependencies": {
     "eslint": "^6.8.0",
     "intelli-espower-loader": "^1.0.1",
-    "koa-joi-router": "^6.0.0",
+    "koa-joi-router": "^7.0.0",
     "mocha": "^7.1.1",
     "power-assert": "^1.6.1",
     "standard-version": "^7.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,36 +18,46 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@hapi/address@2.x.x":
+"@hapi/hoek@^9.0.0":
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.1.1.tgz#9daf5745156fd84b8e9889a2dc721f0c58e894aa"
+  integrity sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw==
+
+"@hapi/topo@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-5.0.0.tgz#c19af8577fa393a06e9c77b60995af959be721e7"
+  integrity sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+
+"@koa/router@8.0.2":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@koa/router/-/router-8.0.2.tgz#46a48d58cb0d76dc7a3735f14d1e66bbe2116575"
+  integrity sha512-7Wa8yXBmz9HjmZOr+xfMVuxFPNObdkiQFBiwF9SQ8zFqHykwBHcJA/mLqqxU2NKoeXRPBKUOPeOjwgR+gyadcA==
+  dependencies:
+    debug "^3.1.0"
+    http-errors "^1.3.1"
+    koa-compose "^3.0.0"
+    methods "^1.0.1"
+    path-to-regexp "^1.1.1"
+    urijs "^1.19.0"
+
+"@sideway/address@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.0.tgz#0b301ada10ac4e0e3fa525c90615e0b61a72b78d"
+  integrity sha512-wAH/JYRXeIFQRsxerIuLjgUu2Xszam+O5xKeatJ4oudShOOirfmsQ1D6LL54XOU2tizpCYku+s1wmU0SYdpoSA==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+
+"@sideway/formula@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@sideway/formula/-/formula-3.0.0.tgz#fe158aee32e6bd5de85044be615bc08478a0a13c"
+  integrity sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==
+
+"@sideway/pinpoint@^2.0.0":
   version "2.0.0"
-  resolved "https://registry.npmjs.org/@hapi/address/-/address-2.0.0.tgz#9f05469c88cb2fd3dcd624776b54ee95c312126a"
-  integrity sha512-mV6T0IYqb0xL1UALPFplXYQmR0twnXG0M6jUswpquqT2sD12BOiCiLy3EvMp/Fy7s3DZElC4/aPjEjo2jeZpvw==
-
-"@hapi/hoek@6.x.x":
-  version "6.2.4"
-  resolved "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz#4b95fbaccbfba90185690890bdf1a2fbbda10595"
-  integrity sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==
-
-"@hapi/hoek@8.x.x":
-  version "8.2.1"
-  resolved "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.2.1.tgz#924af04cbb22e17359c620d2a9c946e63f58eb77"
-  integrity sha512-JPiBy+oSmsq3St7XlipfN5pNA6bDJ1kpa73PrK/zR29CVClDVqy04AanM/M/qx5bSF+I61DdCfAvRrujau+zRg==
-
-"@hapi/joi@15.0.0":
-  version "15.0.0"
-  resolved "https://registry.npmjs.org/@hapi/joi/-/joi-15.0.0.tgz#675d227b4c10d902fc5a96a2235665f0bc292e1b"
-  integrity sha512-pLCfcSeT26g59jEKZntmzlqe19dRMDNxCFKGD4CriF8+9FAD3Mq1aWNuKIFpKpX+u3x8lxLKXolDwk0gYl3b2w==
-  dependencies:
-    "@hapi/address" "2.x.x"
-    "@hapi/hoek" "6.x.x"
-    "@hapi/topo" "3.x.x"
-
-"@hapi/topo@3.x.x":
-  version "3.1.3"
-  resolved "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.3.tgz#c7a02e0d936596d29f184e6d7fdc07e8b5efce11"
-  integrity sha512-JmS9/vQK6dcUYn7wc2YZTqzIKubAQcJKu2KCKAru6es482U5RT5fP1EXCPtlXpiK7PR0On/kpQKI4fRKkzpZBQ==
-  dependencies:
-    "@hapi/hoek" "8.x.x"
+  resolved "https://registry.yarnpkg.com/@sideway/pinpoint/-/pinpoint-2.0.0.tgz#cff8ffadc372ad29fd3f78277aeb29e632cc70df"
+  integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
 
 "@types/color-name@^1.1.1":
   version "1.1.1"
@@ -1221,9 +1231,10 @@ flatted@^2.0.0:
   resolved "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz#69e57caa8f0eacbc281d2e2cb458d46fdb449e08"
   integrity sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
 
-flatten@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
+flatten@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.3.tgz#c1283ac9f27b368abc1e36d1ff7b04501a30356b"
+  integrity sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==
 
 foreach@^2.0.5:
   version "2.0.5"
@@ -1638,6 +1649,24 @@ isexe@^2.0.0:
   resolved "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
+joi-to-swagger@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/joi-to-swagger/-/joi-to-swagger-5.2.0.tgz#d9c770050eed09e8d1d0d5b23b9101bcfdcd3ef6"
+  integrity sha512-G/zr+j9L7UslwuYu3HEeX/IO/0PUb1ESwhDz8VqQOLbYWiEpD6ymaCeR0Eyko4WCN5IAOJ4vXj23ZI2M/GpwNg==
+  dependencies:
+    lodash "^4.17.20"
+
+joi@^17.2.1:
+  version "17.3.0"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-17.3.0.tgz#f1be4a6ce29bc1716665819ac361dfa139fff5d2"
+  integrity sha512-Qh5gdU6niuYbUIUV5ejbsMiiFmBdw8Kcp8Buj2JntszCkCfxJ9Cz76OtHxOZMPXrt5810iDIXs+n1nNVoquHgg==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+    "@hapi/topo" "^5.0.0"
+    "@sideway/address" "^4.1.0"
+    "@sideway/formula" "^3.0.0"
+    "@sideway/pinpoint" "^2.0.0"
+
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -1682,34 +1711,22 @@ koa-compose@^3.0.0:
   dependencies:
     any-promise "^1.1.0"
 
-koa-joi-router@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.npmjs.org/koa-joi-router/-/koa-joi-router-6.0.0.tgz#072ad3bfefb31b161166dfd70e567a0d86e24848"
-  integrity sha512-h2KSH4HfVr02wGi+AR8OIRZlJRoAzJ/6f/CXaU06EjLK3zuB2ftOw7SAhTzL7Fjsu1aM4u9EM5FtTxv984c0bg==
+koa-joi-router@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/koa-joi-router/-/koa-joi-router-7.0.0.tgz#8e02e27fea56b9e7f81690b2e95faf0cb3e15e1c"
+  integrity sha512-d++c6a2F1bPCqgbvnoZ5FCtxikQbbDJr51faMhvY8DzN05fQfsbAs4JfKIe4FhWgiRe5LE70WpxW9WLG0kPpEQ==
   dependencies:
-    "@hapi/joi" "15.0.0"
+    "@koa/router" "8.0.2"
     await-busboy "1.0.3"
     clone "2.1.2"
     co-body "6.0.0"
     debug "4.1.1"
     delegates "1.0.0"
-    flatten "1.0.2"
+    flatten "1.0.3"
     is-gen-fn "0.0.1"
-    koa-router "7.4.0"
+    joi "^17.2.1"
     methods "1.1.2"
     sliced "1.0.1"
-
-koa-router@7.4.0:
-  version "7.4.0"
-  resolved "https://registry.npmjs.org/koa-router/-/koa-router-7.4.0.tgz#aee1f7adc02d5cb31d7d67465c9eacc825e8c5e0"
-  integrity sha512-IWhaDXeAnfDBEpWS6hkGdZ1ablgr6Q6pGdXCyK38RbzuH4LkUOpPqPw+3f8l8aTDrQmBQ7xJc0bs2yV4dzcO+g==
-  dependencies:
-    debug "^3.1.0"
-    http-errors "^1.3.1"
-    koa-compose "^3.0.0"
-    methods "^1.0.1"
-    path-to-regexp "^1.1.1"
-    urijs "^1.19.0"
 
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
@@ -1791,6 +1808,11 @@ lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
+lodash@^4.17.20:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
 log-symbols@3.0.0:
   version "3.0.0"
@@ -2027,13 +2049,6 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
   integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
-
-o2team-joi-to-swagger@^3.2.2:
-  version "3.2.2"
-  resolved "https://registry.npmjs.org/o2team-joi-to-swagger/-/o2team-joi-to-swagger-3.2.2.tgz#52c337a4d80bc3195d9dc4c5682b8093fdbb7102"
-  integrity sha512-9OfFltFX/q8XmuFO0I932Q4Fpu9Ys40Qs778gblvTYcliCRpnxQ71rbyUCa+w8eZUwBH9XcSVL+w8V27Td0oKw==
-  dependencies:
-    lodash "^4.17.11"
 
 object-assign@^4.0.1:
   version "4.1.1"


### PR DESCRIPTION
Switched to using joi-to-swagger instead of o2team-joi-to-swagger, since o2team-joi-to-swagger is outdated.
Updated koa-joi-router to ^7.0.0 from ^6.0.0.

Closes #29 